### PR TITLE
Remove unused "mz" dependency

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+Unreleased
+=================
+
+ * Remove unused "mz" dependency
 
 2.1.0 / 2020-02-27
 ==================

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "mocha": "^10.0.0",
     "supertest": "^6.2.4"
   },
-  "dependencies": {
-    "mz": "^2.7.0"
-  },
   "license": "MIT",
   "scripts": {
     "test": "NODE_ENV=test mocha --reporter spec --exit",


### PR DESCRIPTION
The "mz" package is completely unused. I noticed this because mz pulled in an old version of thenify that has a "critical" level advisory alert: https://github.com/advisories/GHSA-29xr-v42j-r956

Unit tests still pass. Grepped for "mz" and found nothing.
